### PR TITLE
updating the stream table queries to use the public tables

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -300,17 +300,14 @@ def geometry(
 
         # Construct the BigQuery query to select specific columns with a JOIN statement
         query = f"""
-            SELECT *
+            SELECT 
+                *
             FROM 
-                `nwm-ciroh.NWM_Streams_Tables.NWMApp_CONUS` AS a
-            JOIN 
-                `nwm-ciroh.NWM_Streams_Tables.Routelink_CONUS_fsspec` AS b
-            ON 
-                a.station_id = b.to
+                `bigquery-public-data.national_water_model.stream_network`
             WHERE 
-                a.station_id IN ({", ".join(map(str, station_ids))})
+                station_id IN ({", ".join(map(str, station_ids))})
             ORDER BY 
-                a.station_id
+                station_id
         """
 
     elif hydroshare_id:
@@ -329,17 +326,14 @@ def geometry(
 
         # Construct the BigQuery query to select specific columns with a JOIN statement
         query = f"""
-            SELECT *
+            SELECT 
+                *
             FROM 
-                `nwm-ciroh.NWM_Streams_Tables.NWMApp_CONUS` AS a
-            JOIN 
-                `nwm-ciroh.NWM_Streams_Tables.Routelink_CONUS_fsspec` AS b
-            ON 
-                a.station_id = b.to
+                `bigquery-public-data.national_water_model.stream_network`
             WHERE 
-                a.station_id IN ({", ".join(map(str, station_ids))})
+                station_id IN ({", ".join(map(str, station_ids))})
             ORDER BY 
-                a.station_id
+                station_id
         """
     
     elif lat and lon:
@@ -349,7 +343,7 @@ def geometry(
                 streams.*,    
                 ST_DISTANCE(streams.geometry, ST_GEOGPOINT({lon}, {lat})) AS distance
             FROM
-                `nwm-ciroh.NWM_Streams_Tables.NWMApp_CONUS` AS streams
+                `bigquery-public-data.national_water_model.stream_network` AS streams
             ORDER BY distance
             LIMIT 1
         """


### PR DESCRIPTION
Old tables for the streams were ACL'ed to just the users of the `nwm-ciroh` project, this points the queries to use the stream network table in the public dataset.