### PR TITLE
Update image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # api-nwm-gcp
 REST API backed by National Water Model data, developed on Google Cloud Platform. This repository contains general architecture diagram for a general understanding, but it focuses on two GCP products and their respective set up files and configurations: Cloud Functions and API Gateway.
 
-![Architecture Diagram](images/gcp_architecture_diagram.png)
+![Architecture Diagram](https://github.com/BYU-Hydroinformatics/api-nwm-gcp/blob/main/images/gcp_architecture_diagram.png)
 
 ## Infrastructure setup
 


### PR DESCRIPTION
i tried adding the readme page on ciroh docuhub (https://docs.ciroh.org/docs/products/bigqeury-api/) but it is not rendering the image correctly. so i changed the image path to use absolute url instead which should fix the issue.